### PR TITLE
feat: enable login with jwt

### DIFF
--- a/MODIFICATION.md
+++ b/MODIFICATION.md
@@ -1,0 +1,38 @@
+# Superset server modification by @mar-bi
+
+## Goals:
+
+1. add a JWT login in order to show charts and metrics via embedded iframes in another (non-superset) client app.
+2. login to superset from the client app with a single **'GET'** request which contains a JWT token as a url string parameter. Sending `csrf_token` and `cookies` is not required.
+3. keep original superset login with username & password.
+4. potentially solve **Safari** browser's default behavior for NOT sending cookies in **CORS** requests. (_still need to verify_).
+
+## Implementation details
+
+- `SupersetSecurityManager` class modified to have an alternative auth view (`authdbview` property).
+- `CustomAuthDBView` class added to enable login with JWT tokens.
+
+## Running superset locally
+
+- enable **"CORS"** in `superset_config.py` if `PYTONPATH` is set or in `config.py` otherwise:
+
+```js
+ENABLE_CORS = True;
+CORS_OPTIONS = {
+  supports_credentials: True,
+  allow_headers: ['Content-Type', 'Origin', 'X-Requested-With', 'Accept'],
+  resources: ['/login/', '/', '/superset/welcome'],
+  origins: ['http://localhost:3000'], // your client app host
+};
+```
+
+## Using JWT login in the client app
+
+- Login to superset with JWT via this endpoint: `SUPER_SET_URL/login/?token=jwt_token`
+- JWT token description:
+  1. required field in JWT claims - `user_name` should correspond to username in superset
+  2. can modify **"secret"** and **algorithm** for JWT right in `superset/custom_view/views.py`
+
+## Credits
+
+I used this article to implement the JWT login to superset - [Tutorial - How to integrate superset in your own application](https://programmer.group/tutorial-how-to-integrate-superset-in-your-own-application.html)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-Superset
-=========
+
+# Superset
 
 [![Build Status](https://travis-ci.org/apache/incubator-superset.svg?branch=master)](https://travis-ci.org/apache/incubator-superset)
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
@@ -35,7 +35,7 @@ Superset
 
 A modern, enterprise-ready business intelligence web application.
 
-[**Why Superset**](#why-superset) | 
+[**Why Superset**](#why-superset) |
 [**Database Support**](#database-support) |
 [**Installation and Configuration**](#installation-and-configuration) |
 [**Get Help**](#get-help) |
@@ -44,6 +44,9 @@ A modern, enterprise-ready business intelligence web application.
 [**Superset Users**](#superset-users) |
 [**License**](#license) |
 
+## Superset JWT Login
+
+All details about this fork can be found in [MODIFICATION.md](MODIFICATION.md)
 
 ## Screenshots & Gifs
 
@@ -70,25 +73,25 @@ A modern, enterprise-ready business intelligence web application.
 ## Why Superset
 
 Superset provides:
-* An intuitive interface to explore and visualize datasets, and
-    create interactive dashboards.
-* A wide array of beautiful visualizations to showcase your data.
-* Easy, code-free, user flows to drill down and slice and dice the data
-    underlying exposed dashboards. The dashboards and charts act as a starting
-    point for deeper analysis.
-* A state of the art SQL editor/IDE exposing a rich metadata browser, and
-    an easy workflow to create visualizations out of any result set.
-* An extensible, high granularity security model allowing intricate rules
-    on who can access which product features and datasets.
-    Integration with major
-    authentication backends (database, OpenID, LDAP, OAuth, REMOTE_USER, ...)
-* A lightweight semantic layer, allowing to control how data sources are
-    exposed to the user by defining dimensions and metrics
-* Out of the box support for most SQL-speaking databases
-* Deep integration with Druid allows for Superset to stay blazing fast while
-    slicing and dicing large, realtime datasets
-* Fast loading dashboards with configurable caching
 
+- An intuitive interface to explore and visualize datasets, and
+  create interactive dashboards.
+- A wide array of beautiful visualizations to showcase your data.
+- Easy, code-free, user flows to drill down and slice and dice the data
+  underlying exposed dashboards. The dashboards and charts act as a starting
+  point for deeper analysis.
+- A state of the art SQL editor/IDE exposing a rich metadata browser, and
+  an easy workflow to create visualizations out of any result set.
+- An extensible, high granularity security model allowing intricate rules
+  on who can access which product features and datasets.
+  Integration with major
+  authentication backends (database, OpenID, LDAP, OAuth, REMOTE_USER, ...)
+- A lightweight semantic layer, allowing to control how data sources are
+  exposed to the user by defining dimensions and metrics
+- Out of the box support for most SQL-speaking databases
+- Deep integration with Druid allows for Superset to stay blazing fast while
+  slicing and dicing large, realtime datasets
+- Fast loading dashboards with configurable caching
 
 ## Database Support
 
@@ -97,120 +100,116 @@ SQL toolkit that is compatible with most databases. A list of
 supported databases can be found
 [here](https://superset.incubator.apache.org/#databases).
 
-
 ## Installation and Configuration
 
 [See in the documentation](https://superset.incubator.apache.org/installation.html)
 
-
 ## Get Help
 
-* [Stackoverflow tag](https://stackoverflow.com/questions/tagged/apache-superset)
-* [Join Community Slack](https://join.slack.com/t/apache-superset/shared_invite/enQtNDMxMDY5NjM4MDU0LWJmOTcxYjlhZTRhYmEyYTMzOWYxOWEwMjcwZDZiNWRiNDY2NDUwNzcwMDFhNzE1ZmMxZTZlZWY0ZTQ2MzMyNTU)
-* [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
-
+- [Stackoverflow tag](https://stackoverflow.com/questions/tagged/apache-superset)
+- [Join Community Slack](https://join.slack.com/t/apache-superset/shared_invite/enQtNDMxMDY5NjM4MDU0LWJmOTcxYjlhZTRhYmEyYTMzOWYxOWEwMjcwZDZiNWRiNDY2NDUwNzcwMDFhNzE1ZmMxZTZlZWY0ZTQ2MzMyNTU)
+- [Mailing list](https://lists.apache.org/list.html?dev@superset.apache.org)
 
 ## Contributor Guide
 
 Interested in contributing? Check out
 [Contributing.MD](https://github.com/apache/superset/blob/master/CONTRIBUTING.md) to learn how to contribute and best practices.
 
-
 ## Resources
 
-* [Blog](https://preset.io/blog/)
-* [Docker image](https://hub.docker.com/r/preset/superset/)
-* [Youtube Channel](https://www.youtube.com/channel/UCMuwrvBsg_jjI2gLcm04R0g)
-  * [May 15, 2020: Virtual Meetup Recording. Topics: 0.36 Overview, Committers Self-Intro, Roadmap](https://www.youtube.com/watch?v=tXGDmqjmcTs&t=20s)
+- [Blog](https://preset.io/blog/)
+- [Docker image](https://hub.docker.com/r/preset/superset/)
+- [Youtube Channel](https://www.youtube.com/channel/UCMuwrvBsg_jjI2gLcm04R0g)
+  - [May 15, 2020: Virtual Meetup Recording. Topics: 0.36 Overview, Committers Self-Intro, Roadmap](https://www.youtube.com/watch?v=tXGDmqjmcTs&t=20s)
 
 ## Superset Users
 
 Here's a list of organizations that have taken the time to send a PR to let
 the world know they are using Superset. If you are a user and want to be recognized,
-all you have to do is file a simple PR [like this one](https://github.com/apache/incubator-superset/pull/7576). 
+all you have to do is file a simple PR [like this one](https://github.com/apache/incubator-superset/pull/7576).
 Join our growing community!
 
- 1. [6play](https://www.6play.fr) [@CoryChaplin]
- 1. [AiHello](https://www.aihello.com) [@ganeshkrishnan1]
- 1. [Airbnb](https://github.com/airbnb) 
- 1. [Airboxlab](https://foobot.io) [@antoine-galataud]
- 1. [Aktia Bank plc](https://www.aktia.com) [@villebro]
- 1. [American Express](https://www.americanexpress.com) [@TheLastSultan]
- 1. [Amino](https://amino.com) [@shkr]
- 1. [Apollo GraphQL](https://www.apollographql.com/) [@evans]
- 1. [Ascendica Development](http://ascendicadevelopment.com) [@davidhassan]
- 1. [Astronomer](https://www.astronomer.io) [@ryw]
- 1. [bilibili](https://www.bilibili.com) [@Moinheart]
- 1. [Brilliant.org](https://brilliant.org/) 
- 1. [Capital Service S.A.](http://capitalservice.pl) [@pkonarzewski]
- 1. [Clark.de](http://clark.de/) 
- 1. [Cloudsmith](https://cloudsmith.io) [@alancarson]
- 1. [CnOvit](http://www.cnovit.com/) [@xieshaohu]
- 1. [Deepomatic](https://deepomatic.com/) [@Zanoellia]
- 1. [Dial Once](https://www.dial-once.com/en/) 
- 1. [Digit Game Studios](https://www.digitgaming.com/)
- 1. [Douban](https://www.douban.com/) [@luchuan]
- 1. [Dragonpass](https://www.dragonpass.com.cn/) [@zhxjdwh]
- 1. [Dremio](https://dremio.com) [@narendrans]
- 1. [Endress+Hauser](http://www.endress.com/) [@rumbin]
- 1. [Faasos](http://faasos.com/) [@shashanksingh]
- 1. [Fanatics](https://www.fanatics.com) [@coderfender]
- 1. [FBK - ICT center](http://ict.fbk.eu) 
- 1. [Fordeal](http://www.fordeal.com) [@Renkai]
- 1. [GFG - Global Fashion Group](https://global-fashion-group.com) [@ksaagariconic]
- 1. [GfK Data Lab](http://datalab.gfk.com) [@mherr]
- 1. [Grassroot](https://www.grassrootinstitute.org/) 
- 1. [Hostnfly](https://www.hostnfly.com/) [@alexisrosuel]
- 1. [HuiShouBao](http://www.huishoubao.com/) [@Yukinoshita-Yukino]
- 1. [Intercom](https://www.intercom.com/) [@kate-gallo]
- 1. [jampp](https://jampp.com/) 
- 1. [komoot](https://www.komoot.com/) [@christophlingg]
- 1. [Konfío](http://konfio.mx) [@uis-rodriguez]
- 1. [Kuaishou](https://www.kuaishou.com/) [@zhaoyu89730105]
- 1. [Let's Roam](https://www.letsroam.com/) 
- 1. [Lime](https://www.limebike.com/) [@cxmcc]
- 1. [Living Goods](https://www.livinggoods.org) [@chelule]
- 1. [Lyft](https://www.lyft.com/) 
- 1. [Maieutical Labs](https://maieuticallabs.it) [@xrmx]
- 1. [Myra Labs](http://www.myralabs.com/) [@viksit]
- 1. [Now](https://www.now.vn/) [@davidkohcw]
- 1. [Ona](https://ona.io) [@pld]
- 1. [Peak AI](https://www.peak.ai/) [@azhar22k]
- 1. [PeopleDoc](https://www.people-doc.com) [@rodo]
- 1. [Popoko VM Games Studio](https://popoko.live) 
- 1. [Preset, Inc.](https://preset.io) 
- 1. [Pronto Tools](http://www.prontotools.io) [@zkan]
- 1. [PubNub](https://pubnub.com) [@jzucker2]
- 1. [QPID Health](http://www.qpidhealth.com/) 
- 1. [Qunar](https://www.qunar.com/) [@flametest]
- 1. [Rakuten Viki](https://www.viki.com) 
- 1. [Reward Gateway](https://www.rewardgateway.com) 
- 1. [Safaricom](https://www.safaricom.co.ke/) [@mmutiso]
- 1. [Scoot](https://scoot.co/) [@haaspt]
- 1. [ScopeAI](https://www.getscopeai.com) [@iloveluce]
- 1. [Shopee](https://shopee.sg) [@xiaohanyu]
- 1. [Shopkick](https://www.shopkick.com) [@LAlbertalli]
- 1. [Showmax](https://tech.showmax.com) [@bobek]
- 1. [source{d}](https://www.sourced.tech) [@marnovo]
- 1. [Steamroot](https://streamroot.io/) 
- 1. [Tails.com](https://tails.com) [@alanmcruickshank]
- 1. [Tenable](https://www.tenable.com) [@dflionis]
- 1. [THE ICONIC](http://theiconic.com.au/) [@ksaagariconic]
- 1. [timbr.ai](https://timbr.ai/) [@semantiDan]
- 1. [TME QQMUSIC/WESING](https://www.tencentmusic.com/) 
- 1. [Tobii](http://www.tobii.com/) [@dwa]
- 1. [Tooploox](https://www.tooploox.com/) [@jakubczaplicki]
- 1. [TrustMedis](https://trustmedis.com) [@famasya]
- 1. [Twitter](https://twitter.com/) 
- 1. [Udemy](https://www.udemy.com/) [@sungjuly]
- 1. [VIPKID](https://www.vipkid.com.cn/) [@illpanda]
- 1. [WeSure](https://www.wesure.cn/)
- 1. [Whale](http://whale.im)
- 1. [Windsor.ai](https://www.windsor.ai/) [@octaviancorlade]
- 1. [Yahoo!](https://yahoo.com/) 
- 1. [Zaihang](http://www.zaih.com/)
- 1. [Zalando](https://www.zalando.com) [@dmigo]
- 1. [Zalora](https://www.zalora.com) [@ksaagariconic]
+1.  [6play](https://www.6play.fr) [@CoryChaplin]
+1.  [AiHello](https://www.aihello.com) [@ganeshkrishnan1]
+1.  [Airbnb](https://github.com/airbnb)
+1.  [Airboxlab](https://foobot.io) [@antoine-galataud]
+1.  [Aktia Bank plc](https://www.aktia.com) [@villebro]
+1.  [American Express](https://www.americanexpress.com) [@TheLastSultan]
+1.  [Amino](https://amino.com) [@shkr]
+1.  [Apollo GraphQL](https://www.apollographql.com/) [@evans]
+1.  [Ascendica Development](http://ascendicadevelopment.com) [@davidhassan]
+1.  [Astronomer](https://www.astronomer.io) [@ryw]
+1.  [bilibili](https://www.bilibili.com) [@Moinheart]
+1.  [Brilliant.org](https://brilliant.org/)
+1.  [Capital Service S.A.](http://capitalservice.pl) [@pkonarzewski]
+1.  [Clark.de](http://clark.de/)
+1.  [Cloudsmith](https://cloudsmith.io) [@alancarson]
+1.  [CnOvit](http://www.cnovit.com/) [@xieshaohu]
+1.  [Deepomatic](https://deepomatic.com/) [@Zanoellia]
+1.  [Dial Once](https://www.dial-once.com/en/)
+1.  [Digit Game Studios](https://www.digitgaming.com/)
+1.  [Douban](https://www.douban.com/) [@luchuan]
+1.  [Dragonpass](https://www.dragonpass.com.cn/) [@zhxjdwh]
+1.  [Dremio](https://dremio.com) [@narendrans]
+1.  [Endress+Hauser](http://www.endress.com/) [@rumbin]
+1.  [Faasos](http://faasos.com/) [@shashanksingh]
+1.  [Fanatics](https://www.fanatics.com) [@coderfender]
+1.  [FBK - ICT center](http://ict.fbk.eu)
+1.  [Fordeal](http://www.fordeal.com) [@Renkai]
+1.  [GFG - Global Fashion Group](https://global-fashion-group.com) [@ksaagariconic]
+1.  [GfK Data Lab](http://datalab.gfk.com) [@mherr]
+1.  [Grassroot](https://www.grassrootinstitute.org/)
+1.  [Hostnfly](https://www.hostnfly.com/) [@alexisrosuel]
+1.  [HuiShouBao](http://www.huishoubao.com/) [@Yukinoshita-Yukino]
+1.  [Intercom](https://www.intercom.com/) [@kate-gallo]
+1.  [jampp](https://jampp.com/)
+1.  [komoot](https://www.komoot.com/) [@christophlingg]
+1.  [Konfío](http://konfio.mx) [@uis-rodriguez]
+1.  [Kuaishou](https://www.kuaishou.com/) [@zhaoyu89730105]
+1.  [Let's Roam](https://www.letsroam.com/)
+1.  [Lime](https://www.limebike.com/) [@cxmcc]
+1.  [Living Goods](https://www.livinggoods.org) [@chelule]
+1.  [Lyft](https://www.lyft.com/)
+1.  [Maieutical Labs](https://maieuticallabs.it) [@xrmx]
+1.  [Myra Labs](http://www.myralabs.com/) [@viksit]
+1.  [Now](https://www.now.vn/) [@davidkohcw]
+1.  [Ona](https://ona.io) [@pld]
+1.  [Peak AI](https://www.peak.ai/) [@azhar22k]
+1.  [PeopleDoc](https://www.people-doc.com) [@rodo]
+1.  [Popoko VM Games Studio](https://popoko.live)
+1.  [Preset, Inc.](https://preset.io)
+1.  [Pronto Tools](http://www.prontotools.io) [@zkan]
+1.  [PubNub](https://pubnub.com) [@jzucker2]
+1.  [QPID Health](http://www.qpidhealth.com/)
+1.  [Qunar](https://www.qunar.com/) [@flametest]
+1.  [Rakuten Viki](https://www.viki.com)
+1.  [Reward Gateway](https://www.rewardgateway.com)
+1.  [Safaricom](https://www.safaricom.co.ke/) [@mmutiso]
+1.  [Scoot](https://scoot.co/) [@haaspt]
+1.  [ScopeAI](https://www.getscopeai.com) [@iloveluce]
+1.  [Shopee](https://shopee.sg) [@xiaohanyu]
+1.  [Shopkick](https://www.shopkick.com) [@LAlbertalli]
+1.  [Showmax](https://tech.showmax.com) [@bobek]
+1.  [source{d}](https://www.sourced.tech) [@marnovo]
+1.  [Steamroot](https://streamroot.io/)
+1.  [Tails.com](https://tails.com) [@alanmcruickshank]
+1.  [Tenable](https://www.tenable.com) [@dflionis]
+1.  [THE ICONIC](http://theiconic.com.au/) [@ksaagariconic]
+1.  [timbr.ai](https://timbr.ai/) [@semantiDan]
+1.  [TME QQMUSIC/WESING](https://www.tencentmusic.com/)
+1.  [Tobii](http://www.tobii.com/) [@dwa]
+1.  [Tooploox](https://www.tooploox.com/) [@jakubczaplicki]
+1.  [TrustMedis](https://trustmedis.com) [@famasya]
+1.  [Twitter](https://twitter.com/)
+1.  [Udemy](https://www.udemy.com/) [@sungjuly]
+1.  [VIPKID](https://www.vipkid.com.cn/) [@illpanda]
+1.  [WeSure](https://www.wesure.cn/)
+1.  [Whale](http://whale.im)
+1.  [Windsor.ai](https://www.windsor.ai/) [@octaviancorlade]
+1.  [Yahoo!](https://yahoo.com/)
+1.  [Zaihang](http://www.zaih.com/)
+1.  [Zalando](https://www.zalando.com) [@dmigo]
+1.  [Zalora](https://www.zalora.com) [@ksaagariconic]
 
 ## License
 

--- a/superset/custom_views/__init__.py
+++ b/superset/custom_views/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/custom_views/views.py
+++ b/superset/custom_views/views.py
@@ -1,0 +1,33 @@
+import jwt
+# import json
+from flask import flash, g, redirect, request
+from flask_login import login_user
+from flask_appbuilder.security.views import AuthDBView
+from flask_appbuilder.views import expose
+# from flask_appbuilder._compat import as_unicode
+
+'''Change jwt 'secret' to your own before deployment
+    jwt_payload = jwt.decode(token,'secret',algorithms=['HS256'])
+'''
+
+class CustomAuthDBView(AuthDBView):
+
+    @expose('/login/', methods=['GET', 'POST'])
+    def login(self):
+        token = request.args.get('token')
+        if token is not None:
+            jwt_payload = jwt.decode(token,'secret',algorithms=['HS256'])
+            user_name = jwt_payload.get("user_name")
+            user = self.appbuilder.sm.find_user(username=user_name)
+            if user is not None:
+                login_user(user, remember=False)
+                redirect_url = request.args.get('redirect')
+                if not redirect_url:
+                    redirect_url = self.appbuilder.get_url_for_index
+                return redirect(redirect_url)
+            else:
+                return super(CustomAuthDBView, self).login()
+        else:
+            #flash(as_unicode('Unable to auto login'), 'warning')
+            return super(CustomAuthDBView, self).login()
+

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -46,6 +46,7 @@ from superset.constants import RouteMethod
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetSecurityException
 from superset.utils.core import DatasourceName
+from superset.custom_views.views import CustomAuthDBView
 
 if TYPE_CHECKING:
     from superset.common.query_context import QueryContext
@@ -101,6 +102,9 @@ RoleModelView.related_views = []
 
 
 class SupersetSecurityManager(SecurityManager):
+    # override authdbview which is coming from BaseSecurityManager superclass
+    # with our CustomAuthDBView  
+    authdbview = CustomAuthDBView
     userstatschartview = None
     READ_ONLY_MODEL_VIEWS = {"DatabaseAsync", "DatabaseView", "DruidClusterModelView"}
 


### PR DESCRIPTION
### SUMMARY
1. add a JWT login in order to show charts and metrics via embedded iframes in another (non-superset) client app.
2. login to superset from the client app with a single **'GET'** request which contains a JWT token as a url string parameter. Sending `csrf_token` and `cookies` is not required.
3. keep original superset login with username & password.
4. potentially solve **Safari** browser's default behavior for NOT sending cookies in **CORS** requests. (_still need to verify_).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [] Has associated issue:
- [] Changes UI
- [] Requires DB Migration.
- [] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [] Removes existing feature or API
